### PR TITLE
Use 204 status code for response

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var path = require('path');
 var bcrypt = require('bcrypt');
 var ms = require('ms');
@@ -231,7 +230,7 @@ var Login = module.exports = function(app, config) {
           // let lockit handle the response
           if (cfg.handleResponse) {
             // send only JSON when REST is active
-            if (config.rest) return res.send(200);
+            if (config.rest) return res.send(204);
 
             // redirect to target url
             res.redirect(target);
@@ -268,7 +267,7 @@ var Login = module.exports = function(app, config) {
     if (cfg.handleResponse) {
 
       // send JSON when REST is active
-      if (config.rest) return res.send(200);
+      if (config.rest) return res.send(204);
 
       // custom or built-in view
       var view = cfg.views.loggedOut || join('get-logout');


### PR DESCRIPTION
This actually causes an error with no content in jQuery, the statusText becomes the content and a json parse errors on the "OK" message. Response code of 204 indicates that no content should be expected according to http://en.wikipedia.org/wiki/List_of_HTTP_status_codes
