### PR TITLE
fix login page redirect error

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ Login.prototype.getLogin = function(req, res, next) {
   if (config.rest) return next();
 
   // save redirect url
-  var suffix = req.query.redirect ? '?redirect=' + req.query.redirect : '';
+  var suffix = req.query.redirect ? '?redirect=' + encodeURIComponent(req.query.redirect) : '';
 
   // custom or built-in view
   var view = config.login.views.login || join('get-login');


### PR DESCRIPTION
There is an error with current version. Example:
If `GET /login?redirect=%2Foauth2%2Fauth%3Fresponse_type%3Dcode%26client_id%3Dcli`, `Login.getLogin` will generate a html page with a form, whose `action` is `POST /login?redirect=/oauth2/auth?response_type=code&client_id=cli`. This action is incorrect without encodeURIComponent.
