### PR TITLE
Remove the version contraint for couch-pwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "logout"
   ],
   "dependencies": {
-    "couch-pwd": "0.0.1",
+    "couch-pwd": "^0.0.1",
     "lockit-utils": "^0.5.1",
     "moment": "^2.8.1",
     "ms": "^0.7.1"


### PR DESCRIPTION
We current hit an issue ([#1](https://github.com/zemirco/couch-pwd/issues/1)) at [couch-pwd](https://github.com/zemirco/couch-pwd), when we upgrade from node v7 to v8. That problem has been fixed and may be released soon. So it may be good to remove the version constraint here so that we could have the fix in the future. 